### PR TITLE
update reference swerve module state

### DIFF
--- a/src/main/java/frc/lib/team3015/subsystem/selfcheck/SelfCheckingPigeon2.java
+++ b/src/main/java/frc/lib/team3015/subsystem/selfcheck/SelfCheckingPigeon2.java
@@ -53,7 +53,7 @@ public class SelfCheckingPigeon2 implements SelfChecking {
           new SubsystemFault(
               String.format("[%s]: Motion stack loop time was slower than expected", label)));
     }
-    if (pigeon.getFault_SaturatedAccelometer().getValue() == Boolean.TRUE) {
+    if (pigeon.getFault_SaturatedAccelerometer().getValue() == Boolean.TRUE) {
       faults.add(
           new SubsystemFault(String.format("[%s]: Accelerometer values are saturated", label)));
     }

--- a/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
+++ b/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
@@ -266,7 +266,7 @@ public class DrivetrainIOCTRE extends SwerveDrivetrain implements DrivetrainIO {
     Logger.recordOutput("Drivetrain/swerveInputsTime", Logger.getRealTimestamp() - timestamp);
 
     inputs.drivetrain.swerveMeasuredStates = this.getState().ModuleStates;
-    inputs.drivetrain.swerveReferenceStates = swerveReferenceStates;
+    inputs.drivetrain.swerveReferenceStates = this.getState().ModuleTargets;
 
     timestamp = Logger.getRealTimestamp();
 

--- a/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
+++ b/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
@@ -174,13 +174,6 @@ public class DrivetrainIOCTRE extends SwerveDrivetrain implements DrivetrainIO {
 
   private Translation2d centerOfRotation;
   private ChassisSpeeds targetChassisSpeeds;
-  private SwerveModuleState[] swerveReferenceStates =
-      new SwerveModuleState[] {
-        new SwerveModuleState(),
-        new SwerveModuleState(),
-        new SwerveModuleState(),
-        new SwerveModuleState()
-      };
 
   private SwerveRequest.RobotCentric driveRobotCentricRequest = new SwerveRequest.RobotCentric();
   private SwerveRequest.FieldCentric driveFieldCentricRequest = new SwerveRequest.FieldCentric();

--- a/vendordeps/Phoenix6.json
+++ b/vendordeps/Phoenix6.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.0.0-beta-5",
+    "version": "24.0.0-beta-7",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.0.0-beta-5"
+            "version": "24.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.0.0-beta-5",
+            "version": "24.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
already supported in generic drivetrain; added to Phoenix 6 beta 7 and now supported in CTRE drivetrain as well